### PR TITLE
Cap multicat container log size with json-file rotation

### DIFF
--- a/datasette_interface/docker-compose.yml
+++ b/datasette_interface/docker-compose.yml
@@ -6,6 +6,11 @@ services:
     image: datasette-with-plugins
     container_name: multicat
     restart: unless-stopped
+    logging:
+        driver: json-file
+        options:
+            max-size: "10m"
+            max-file: "3"
     ports:
         - "8001:8001"
     volumes:


### PR DESCRIPTION
## Problem

The `multicat` container's Docker logs were growing without bound. The default `json-file` logging driver has no rotation, so the container's stdout/stderr log file accumulates indefinitely (worsened by datasette's `--reload` mode being chatty).

## Fix

Add a `logging` block to the `datasette` service capping the log at 3 rotated files of 10 MB each (~30 MB ceiling):

```yaml
logging:
    driver: json-file
    options:
        max-size: "10m"
        max-file: "3"
```

## Notes

- This takes effect when the container is (re)created, not on a plain `restart`. The running container has already been recreated via `docker compose up -d` and the config is confirmed live (`max-size: 10m`, `max-file: 3`).
- The pre-existing unbounded log file was truncated separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)