### PR TITLE
Replace OpenReview link with ACL Anthology URL

### DIFF
--- a/datasette_interface/templates/index.html
+++ b/datasette_interface/templates/index.html
@@ -75,10 +75,7 @@ database](https://multicat.lab.pyarelal.xyz/multicat.db).
 ## Citation
 
 If you use this dataset, please cite our [NAACL 2025 Findings
-paper](https://openreview.net/forum?id=nkxpva8fN5) that introduces the dataset.
-
-We will replace the metadata of the citations below with the ones from the
-official ACL Anthology entry when it is published.
+paper](https://aclanthology.org/2025.findings-naacl.61/) that introduces the dataset.
 
 ### BibTeX Format
 

--- a/datasette_interface/templates/pages/papers-and-systems.html
+++ b/datasette_interface/templates/pages/papers-and-systems.html
@@ -9,6 +9,6 @@
 This page lists all the papers and systems that use the dataset. The list is up to
 date as of 2025-03-09.
 
-- [MultiCAT: Multimodal Communication Annotations for Teams](https://openreview.net/forum?id=nkxpva8fN5) (NAACL 2025 Findings): The original dataset paper, which contains benchmark analyses based on the dataset.
+- [MultiCAT: Multimodal Communication Annotations for Teams](https://aclanthology.org/2025.findings-naacl.61/) (NAACL 2025 Findings): The original dataset paper, which contains benchmark analyses based on the dataset.
 """) }}
 {% endblock %}


### PR DESCRIPTION
## Summary

- Replaces the OpenReview preprint link with the official ACL Anthology URL across the datasette interface templates
- Removes the placeholder note about updating citations when the ACL Anthology entry was published
- The BibTeX entry was already updated upstream with the full canonical ACL Anthology citation format

## Test plan

- [ ] Verify all link occurrences point to the ACL Anthology URL
- [ ] Confirm the datasette interface renders correctly